### PR TITLE
Add Warp configuration to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For clients that don't support native remote MCP servers or if you prefer local 
 |--------|----------------------|-----------| 
 | **Claude Desktop (legacy config)** | <details><summary>View Config</summary>**Note**: Only use this if Settings → Integrations doesn't work<br/><pre>{<br/>  "microsoft.docs.mcp": {<br/>    "command": "npx",<br/>    "args": [<br/>      "-y",<br/>      "mcp-remote",<br/>      "https://learn.microsoft.com/api/mcp"<br/>    ]<br/>  }<br/>}</pre>Add to `claude_desktop_config.json`</details>| [Claude Desktop MCP Guide](https://modelcontextprotocol.io/quickstart/user) |
 | **Windsurf** | <details><summary>View Config</summary><pre>{<br/>  "microsoft.docs.mcp": {<br/>    "command": "npx",<br/>    "args": [<br/>      "-y",<br/>      "mcp-remote",<br/>      "https://learn.microsoft.com/api/mcp"<br/>    ]<br/>  }<br/>}</pre> </details>| [Windsurf MCP Guide](https://docs.windsurf.com/windsurf/cascade/mcp) |
+| **Warp** | <details><summary>View Config</summary><pre>{<br/>  "microsoft.docs.mcp": {<br/>    "command": "npx",<br/>    "args": [<br/>      "-y",<br/>      "mcp-remote",<br/>      "https://learn.microsoft.com/api/mcp"<br/>    ],<br/>    "env": { },<br/>    "working_directory": null,<br/>    "start_on_launch": true<br/>  }<br/>}</pre></details> | [Warp MCP Official Guide](https://docs.warp.dev/knowledge-and-collaboration/mcp) 
 
 
 ### ▶️ Getting Started


### PR DESCRIPTION
This PR adds Warp MCP configuration instructions to the README.md file.

## Changes
- Added Warp to the alternative installation table
- Includes manual configuration with npx mcp-remote proxy
- Added link to official Warp MCP guide
- Provides complete configuration example with environment settings

## Why this change?
This addition provides users with clear instructions on how to configure the Microsoft Learn Docs MCP Server with Warp, completing the coverage of major MCP-compatible development environments.